### PR TITLE
Remove neoteroi.openapi extension from MkDocs configuration and add a…

### DIFF
--- a/docs/openapi.md
+++ b/docs/openapi.md
@@ -1,5 +1,6 @@
 # API Reference
 
 ## User Endpoints
+[OAD(./docs/openapi.md)]
 
 ::openapi::openapi.yaml

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,7 +24,6 @@ markdown_extensions:
   - pymdownx.mark
   - pymdownx.tilde
   - pymdownx.details
-  - neoteroi.openapi
 
 extra_css:
   - stylesheets/mkdocsoad.css


### PR DESCRIPTION
… link to the OpenAPI documentation in the API reference.