### PR TITLE
Update OpenAPI reference in documentation index to point to the YAML …

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -32,4 +32,4 @@ graph LR
 # API Reference
 
 ## User Endpoints
-[OAD(./docs/openapi.md)]
+[OAD(./docs/openapi.yaml)]


### PR DESCRIPTION
…file instead of the markdown file.